### PR TITLE
feat: create beer on upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ### Create dump
 
 ```bash
+turso auth login
 turso db shell beer-collection-fresh-test .dump > beer-collection-dump.sql
 ```
 

--- a/cmd/import/main.go
+++ b/cmd/import/main.go
@@ -66,7 +66,7 @@ func main() { //nolint:funlen
 	}
 	s3Client := s3.NewFromConfig(sdkConfig)
 	s3Storage := storage.NewS3Storage(s3Client, logger)
-	imageService := service.NewImageService(&mediaStore, &beerMediaStore, &s3Storage, logger)
+	imageService := service.NewImageService(&mediaStore, &beerStore, &beerMediaStore, &s3Storage, logger)
 	fmt.Println(imageService)
 
 	beerFilter := model.BeerFilter{}

--- a/dumps/beer-collection-dump.sql
+++ b/dumps/beer-collection-dump.sql
@@ -3037,7 +3037,7 @@ CREATE TABLE IF NOT EXISTS `beer_medias` (
  ,  `media_id` integer NOT NULL
  ,  `beer_id` integer NULL
  ,  `type` integer NOT NULL
- ,  CONSTRAINT `fk_beer_id` FOREIGN KEY (`beer_id`) REFERENCES `beers` (`id`)
+ ,  CONSTRAINT `fk_beer_id` FOREIGN KEY (`beer_id`) REFERENCES `beers` (`id`) ON DELETE CASCADE
  ,  CONSTRAINT `fk_media_id` FOREIGN KEY (`media_id`) REFERENCES `media_items` (`id`)
  ,  CONSTRAINT `fk_beer_media_type_id` FOREIGN KEY (`type`) REFERENCES `beer_media_types` (`id`)
  );

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -102,7 +102,7 @@ func InitializeRouter(ctx context.Context, cfg *config.Config, dbClient *db.DbCl
 	geoService := service.NewGeographyService(&geoStore, logger)
 	breweryService := service.NewBreweryService(&breweryStore, &geoStore, logger)
 	beerService := service.NewBeerService(&beerStore, &styleStore, &breweryStore, logger)
-	imageService := service.NewImageService(&mediaStore, &beerMediaStore, &s3Storage, logger)
+	imageService := service.NewImageService(&mediaStore, &beerStore, &beerMediaStore, &s3Storage, logger)
 
 	geoHandler := handler.NewGeographyHandler(geoService, logger)
 	breweryHandler := handler.NewBreweryHandler(breweryService, geoService, logger)

--- a/internal/db/beer_media.go
+++ b/internal/db/beer_media.go
@@ -53,6 +53,17 @@ func (s BeerMediaStore) FetchMediaItems(ctx context.Context, filter model.MediaI
 	return items, result.Error
 }
 
+func (s BeerMediaStore) SimilarMediaItems(ctx context.Context, item model.BeerMedia) ([]model.BeerMedia, error) {
+	var items []model.BeerMedia
+	result := s.db.gorm.
+		Debug().
+		Where("Hash = @hash", map[string]interface{}{"hash": item.Media.Hash}).
+		Joins("Media").
+		Find(&items)
+
+	return items, result.Error
+}
+
 func (s BeerMediaStore) UpdateMediaItems(ctx context.Context, items []model.BeerMedia) error {
 	res := s.db.gorm.
 		Debug().

--- a/internal/model/beer.go
+++ b/internal/model/beer.go
@@ -17,6 +17,13 @@ type Beer struct {
 	BeerMedias  []BeerMedia `gorm:"foreignKey:BeerID;references:ID"`
 }
 
+func NewBeerFromUploadForm(formValue UploadFormValues) Beer {
+	return Beer{
+		Brand:    formValue.Filename,
+		IsActive: false,
+	}
+}
+
 type Brewery struct {
 	ID      int
 	Name    string

--- a/internal/model/beer.go
+++ b/internal/model/beer.go
@@ -1,6 +1,11 @@
 package model
 
-import "time"
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+)
 
 type Beer struct {
 	ID          int `gorm:"primaryKey"`
@@ -18,8 +23,13 @@ type Beer struct {
 }
 
 func NewBeerFromUploadForm(formValue UploadFormValues) Beer {
+	brand := strings.TrimSpace(filepath.Base(formValue.Filename))
+	if ext := filepath.Ext(brand); ext != "" {
+		brand = strings.TrimSuffix(brand, ext)
+	}
+
 	return Beer{
-		Brand:    formValue.Filename,
+		Brand:    fmt.Sprintf("Uncategorized - %s", brand),
 		IsActive: false,
 	}
 }

--- a/internal/model/media_item.go
+++ b/internal/model/media_item.go
@@ -75,7 +75,7 @@ func NewMediaImage(formValues UploadFormValues) (*MediaImage, error) {
 	}
 
 	mediaImage := &MediaImage{
-		ExternalName: fmt.Sprintf("original/%s", formValues.ExternalFilename()),
+		ExternalName: formValues.ExternalFilename(),
 		Bytes:        formValues.Content,
 		Size:         len(formValues.Content),
 		Hash:         formValues.Hash(),

--- a/internal/service/image.go
+++ b/internal/service/image.go
@@ -31,10 +31,8 @@ func NewImageService(mediaStore *db.MediaStore, beerStore *db.BeerStore, beerMed
 }
 
 func (s ImageService) UploadImage(ctx context.Context, formValues []model.UploadFormValues) error {
-
 	extractDigitsRe := regexp.MustCompile(`^(\d+).*\.png$`)
-
-	createdBeersMap := make(map[string]int, 0)
+	fileBeerIDToDBIDMap := make(map[string]int, 0)
 
 	for _, formValue := range formValues {
 		currentBeer := ""
@@ -81,7 +79,7 @@ func (s ImageService) UploadImage(ctx context.Context, formValues []model.Upload
 			return errors.Wrap(uploadErr, "s3 image upload")
 		}
 
-		createdBeer, exists := createdBeersMap[currentBeer]
+		createdBeer, exists := fileBeerIDToDBIDMap[currentBeer]
 		if !exists {
 			s.logger.Info("Creating new beer for image", slog.String("beerId", currentBeer))
 			beer := model.NewBeerFromUploadForm(formValue)
@@ -89,7 +87,7 @@ func (s ImageService) UploadImage(ctx context.Context, formValues []model.Upload
 			if beerErr != nil {
 				return errors.Wrap(beerErr, "insert beer")
 			}
-			createdBeersMap[currentBeer] = beerID
+			fileBeerIDToDBIDMap[currentBeer] = beerID
 			createdBeer = beerID
 		}
 

--- a/internal/service/image.go
+++ b/internal/service/image.go
@@ -32,6 +32,8 @@ func NewImageService(mediaStore *db.MediaStore, beerStore *db.BeerStore, beerMed
 
 func (s ImageService) UploadImage(ctx context.Context, formValues []model.UploadFormValues) error {
 	extractDigitsRe := regexp.MustCompile(`^(\d+).*\.png$`)
+
+	// Map from extracted beer ID (string) to created beer database ID (int)
 	fileBeerIDToDBIDMap := make(map[string]int, 0)
 
 	for _, formValue := range formValues {

--- a/internal/service/image.go
+++ b/internal/service/image.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"log/slog"
+	"regexp"
 
 	"github.com/pkg/errors"
 
@@ -13,14 +14,16 @@ import (
 
 type ImageService struct {
 	mediaStore     *db.MediaStore
+	beerStore      *db.BeerStore
 	beerMediaStore *db.BeerMediaStore
 	s3Storage      *storage.S3Storage
 	logger         *slog.Logger
 }
 
-func NewImageService(mediaStore *db.MediaStore, beerMediaStore *db.BeerMediaStore, s3Storage *storage.S3Storage, logger *slog.Logger) ImageService {
+func NewImageService(mediaStore *db.MediaStore, beerStore *db.BeerStore, beerMediaStore *db.BeerMediaStore, s3Storage *storage.S3Storage, logger *slog.Logger) ImageService {
 	return ImageService{
 		mediaStore:     mediaStore,
+		beerStore:      beerStore,
 		beerMediaStore: beerMediaStore,
 		s3Storage:      s3Storage,
 		logger:         logger,
@@ -28,11 +31,31 @@ func NewImageService(mediaStore *db.MediaStore, beerMediaStore *db.BeerMediaStor
 }
 
 func (s ImageService) UploadImage(ctx context.Context, formValues []model.UploadFormValues) error {
+
+	extractDigitsRe := regexp.MustCompile(`^(\d+).*\.png$`)
+
+	createdBeersMap := make(map[string]int, 0)
+
 	for _, formValue := range formValues {
-		s.logger.Info("Preparing original image", slog.String("originalFilename", formValue.Filename))
+		s.logger.Info("Preparing image", slog.String("originalFilename", formValue.Filename))
 		img, imgErr := model.NewMediaImage(formValue)
 		if imgErr != nil {
-			return errors.Wrap(imgErr, "create original and preview image")
+			return errors.Wrap(imgErr, "create original image")
+		}
+
+		beerMedia := model.BeerMedia{
+			Media: model.MediaItem{
+				Hash: img.Hash,
+			},
+		}
+		images, imagesErr := s.beerMediaStore.SimilarMediaItems(ctx, beerMedia)
+		if imagesErr != nil {
+			return errors.Wrap(imagesErr, "fetch similar beer media items")
+		}
+
+		if len(images) != 0 {
+			s.logger.Info("Skipping image upload, similar image already exists", slog.String("hash", img.Hash), slog.String("filename", formValue.Filename))
+			continue
 		}
 
 		s.logger.Info("Upserting media item", slog.String("originalFilename", formValue.Filename))
@@ -41,14 +64,32 @@ func (s ImageService) UploadImage(ctx context.Context, formValues []model.Upload
 			return errors.Wrap(upsErr, "upsert media item")
 		}
 
-		s.logger.Info("Uploading full-size image", slog.String("name", img.ExternalName), slog.Int("size", img.Size))
+		s.logger.Info("Uploading image to S3", slog.String("name", img.ExternalName), slog.Int("size", img.Size))
 		uploadErr := s.s3Storage.Upload(ctx, img)
 		if uploadErr != nil {
 			return errors.Wrap(uploadErr, "s3 image upload")
 		}
 
+		currentBeer := ""
+		matches := extractDigitsRe.FindStringSubmatch(formValue.Filename)
+		if len(matches) > 0 {
+			currentBeer = matches[1]
+		}
+
+		createdBeer, exists := createdBeersMap[currentBeer]
+		if !exists {
+			s.logger.Info("Creating new beer for image", slog.String("beerId", currentBeer))
+			beer := model.NewBeerFromUploadForm(formValue)
+			beerID, beerErr := s.beerStore.InsertBeer(beer)
+			if beerErr != nil {
+				return errors.Wrap(beerErr, "insert beer")
+			}
+			createdBeersMap[currentBeer] = beerID
+			createdBeer = beerID
+		}
+
 		s.logger.Info("Upserting beer media item", slog.String("originalFilename", formValue.Filename), slog.Any("imageType", img.ImageType))
-		_, insErr := s.beerMediaStore.UpsertBeerMediaItem(ctx, mediaItem, img, formValue.BeerID)
+		_, insErr := s.beerMediaStore.UpsertBeerMediaItem(ctx, mediaItem, img, &createdBeer)
 		if insErr != nil {
 			return errors.Wrap(insErr, "upsert beer media")
 		}

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -29,9 +29,10 @@ func NewS3Storage(client *s3.Client, logger *slog.Logger) S3Storage {
 
 func (s S3Storage) Upload(ctx context.Context, img *model.MediaImage) error {
 	bucket := "beer-collection-bucket"
+	key := fmt.Sprintf("original/%s", img.ExternalName)
 	_, putErr := s.client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:      &bucket,
-		Key:         &img.ExternalName,
+		Key:         &key,
 		Body:        bytes.NewReader(img.Bytes),
 		ContentType: &img.ContentType,
 	})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic creation of new beer records during image uploads based on image filename.
  - Introduced a method to find similar media items by hash.
  - Added a constructor for creating beer records from upload forms.

- **Improvements**
  - Enhanced image upload to prevent duplicate images by checking for similar media items.
  - Uploaded images are now associated with newly created or cached beer records.
  - Updated S3 upload logic to standardize object key formatting.

- **Bug Fixes**
  - Improved foreign key constraints to automatically remove associated media when a beer is deleted.

- **Documentation**
  - Updated README to clarify authentication steps before database operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->